### PR TITLE
Telemetry: Generate fake device readings, for supplying synthetic data 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ calypso-anemometer changelog
 
 in progress
 ===========
+- Telemetry: Generate fake device readings, for supplying synthetic data
 
 
 2022-07-17 0.3.0

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ publish: setup-virtualenv
 	$(twine) upload --skip-existing --verbose dist/*.tar.gz
 
 test: setup-virtualenv
-	$(pip) install --editable=.[test]
+	$(pip) install --editable=.[test,fake]
 	$(pytest)

--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,10 @@ Discover the ``ULTRASONIC`` BLE device and run a conversation on it::
     # Get device readings, continuously at 1 Hz.
     calypso-anemometer read --subscribe --rate=hz_1
 
+    # Generate fake device readings, continuously at 8 Hz.
+    pip install --upgrade calypso-anemometer[fake]
+    calypso-anemometer fake --subscribe --rate=hz_8
+
 If you already discovered your device, know its address, and want to connect
 directly without automatic device discovery, see `skip discovery`_.
 

--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,6 @@ An example NMEA-0183 sentence emitted is::
     $IIVWR,154.0,L,11.06,N,5.69,M,20.48,K*65
 
 
-
 **************
 Other projects
 **************
@@ -187,6 +186,9 @@ Contributions
 Any kind of contribution, feedback or patches are very much welcome! Just `create
 an issue`_ or submit a patch if you think we should include a new feature, or to
 report or fix a bug.
+
+Development
+===========
 
 In order to setup a development environment on your workstation, please head over
 to the `development sandbox`_ documentation. When you see the software tests succeed,

--- a/calypso_anemometer/cli.py
+++ b/calypso_anemometer/cli.py
@@ -10,6 +10,7 @@ import click
 
 from calypso_anemometer.core import CalypsoDeviceApi
 from calypso_anemometer.exception import CalypsoError
+from calypso_anemometer.fake import CalypsoDeviceApiFake
 from calypso_anemometer.model import CalypsoDeviceDataRate, CalypsoDeviceMode, CalypsoReading
 from calypso_anemometer.telemetry import TelemetryAdapter
 from calypso_anemometer.util import EnumChoice, make_sync, setup_logging, wait_forever
@@ -24,15 +25,6 @@ logger = logging.getLogger(__name__)
 @click.pass_context
 def cli(ctx, verbose, debug):
     setup_logging(level=logging.INFO)
-
-
-async def calypso_run(callback: Callable):
-    try:
-        async with CalypsoDeviceApi(ble_address=os.getenv("CALYPSO_ADDRESS")) as calypso:
-            await callback(calypso)
-    except CalypsoError as ex:
-        logger.error(ex)
-        sys.exit(1)
 
 
 @click.command()
@@ -55,6 +47,8 @@ rate_option = click.option(
     required=False,
     help="Set device data rate to one of HZ_1, HZ_4, or HZ_8.",
 )
+subscribe_option = click.option("--subscribe", is_flag=True, required=False, help="Continuously receive readings")
+target_option = click.option("--target", type=str, required=False, help="Submit telemetry data to target")
 
 
 @click.command()
@@ -81,15 +75,52 @@ async def set_option(ctx, mode: Optional[CalypsoDeviceMode] = None, rate: Option
 
 
 @click.command()
-@click.option("--subscribe", is_flag=True, required=False, help="Continuously receive readings")
-@click.option("--target", type=str, required=False, help="Submit telemetry data to target")
+@subscribe_option
+@target_option
 @rate_option
 @click.pass_context
 @make_sync
 async def read(
     ctx, subscribe: bool = False, target: Optional[str] = None, rate: Optional[CalypsoDeviceDataRate] = None
 ):
+    handler = await handler_factory(subscribe=subscribe, target=target, rate=rate)
+    await calypso_run(handler)
 
+
+@click.command()
+@subscribe_option
+@target_option
+@rate_option
+@click.pass_context
+@make_sync
+async def fake(
+    ctx, subscribe: bool = False, target: Optional[str] = None, rate: Optional[CalypsoDeviceDataRate] = None
+):
+    handler = await handler_factory(subscribe=subscribe, target=target, rate=rate)
+    await fake_run(handler)
+
+
+async def calypso_run(callback: Callable):
+    try:
+        async with CalypsoDeviceApi(ble_address=os.getenv("CALYPSO_ADDRESS")) as calypso:
+            await callback(calypso)
+    except CalypsoError as ex:
+        logger.error(ex)
+        sys.exit(1)
+
+
+async def fake_run(callback: Callable):
+    try:
+        async with CalypsoDeviceApiFake(ble_address=os.getenv("CALYPSO_ADDRESS")) as calypso:
+            await callback(calypso)
+    except CalypsoError as ex:
+        logger.error(ex)
+        sys.exit(1)
+
+
+async def handler_factory(
+    subscribe: bool = False, target: Optional[str] = None, rate: Optional[CalypsoDeviceDataRate] = None
+):
     telemetry = None
     if target is not None:
         telemetry = TelemetryAdapter(uri=target)
@@ -115,10 +146,11 @@ async def read(
             await calypso.subscribe_reading(process_reading)
             await wait_forever()
 
-    await calypso_run(handler)
+    return handler
 
 
 cli.add_command(info, name="info")
 cli.add_command(explore, name="explore")
 cli.add_command(set_option, name="set-option")
 cli.add_command(read, name="read")
+cli.add_command(fake, name="fake")

--- a/calypso_anemometer/cli.py
+++ b/calypso_anemometer/cli.py
@@ -12,7 +12,7 @@ from calypso_anemometer.core import CalypsoDeviceApi
 from calypso_anemometer.exception import CalypsoError
 from calypso_anemometer.model import CalypsoDeviceDataRate, CalypsoDeviceMode, CalypsoReading
 from calypso_anemometer.telemetry import TelemetryAdapter
-from calypso_anemometer.util import EnumChoice, make_sync, setup_logging, to_json, wait_forever
+from calypso_anemometer.util import EnumChoice, make_sync, setup_logging, wait_forever
 
 logger = logging.getLogger(__name__)
 

--- a/calypso_anemometer/core.py
+++ b/calypso_anemometer/core.py
@@ -206,8 +206,8 @@ class CalypsoDeviceApi:
     async def set_mode(self, mode: CalypsoDeviceMode):
         await self.client.write_gatt_char(CHARSPEC_MODE.uuid, data=bytes([mode.value]), response=True)
 
-    async def set_datarate(self, mode: CalypsoDeviceDataRate):
-        await self.client.write_gatt_char(CHARSPEC_DATARATE.uuid, data=bytes([mode.value]), response=True)
+    async def set_datarate(self, rate: CalypsoDeviceDataRate):
+        await self.client.write_gatt_char(CHARSPEC_DATARATE.uuid, data=bytes([rate.value]), response=True)
 
     async def get_reading(self):
         logger.info("Requesting reading")

--- a/calypso_anemometer/fake.py
+++ b/calypso_anemometer/fake.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# (c) 2022 Andreas Motl <andreas.motl@panodata.org>
+# License: GNU Affero General Public License, Version 3
+import dataclasses
+import logging
+from copy import deepcopy
+from typing import Callable, Optional
+
+import aiorate
+
+from calypso_anemometer.model import CalypsoDeviceDataRate, CalypsoReading
+
+logger = logging.getLogger(__name__)
+
+MINIMUM_VALUES = CalypsoReading(
+    wind_speed=0,
+    wind_direction=0,
+    battery_level=0,
+    temperature=-100,
+    roll=-90,
+    pitch=-90,
+    compass=0,
+)
+
+MAXIMUM_VALUES = CalypsoReading(
+    wind_speed=40,
+    wind_direction=360,
+    battery_level=100,
+    temperature=+100,
+    roll=+90,
+    pitch=+90,
+    compass=360,
+)
+
+
+class CalypsoDeviceApiFake:
+
+    NAME = "calypso-up10-fake"
+    DESCRIPTION = "Calypso UP10 anemometer fake device"
+
+    def __init__(self, ble_address: Optional[str] = None):
+        self.ble_address: str = ble_address
+        self.datarate: CalypsoDeviceDataRate = CalypsoDeviceDataRate.HZ_4
+        self.reading: Optional[CalypsoReading] = None
+
+    async def __aenter__(self):
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.disconnect()
+        if exc_val is not None:
+            raise exc_val
+
+    async def discover(self, force=False) -> bool:
+        self.ble_address = "fake-ble-address"
+        return True
+
+    async def connect(self):
+        self.reading = deepcopy(MINIMUM_VALUES)
+
+    async def disconnect(self):
+        self.reading = None
+
+    async def set_datarate(self, rate: CalypsoDeviceDataRate):
+        self.datarate = rate
+
+    async def get_reading(self):
+        logger.info("Producing reading")
+        return await self.produce_fake_reading()
+
+    async def subscribe_reading(self, callback: Optional[Callable] = None):
+        """
+        Fake async reading producer task, emulating responses to a BLE subscribe/notify.
+        """
+        logger.info("Subscribing to readings")
+        rate = aiorate.Rate(self.datarate.value)
+        while True:
+            reading = await self.produce_fake_reading()
+            callback(reading)
+            await rate.sleep()
+
+    async def produce_fake_reading(self):
+        """
+        Produce an artificial reading with incrementing values,
+        wrapping around at a maximum limit per measurement.
+        """
+        for field in dataclasses.fields(self.reading):
+            current_value = getattr(self.reading, field.name)
+            minimum_value = getattr(MINIMUM_VALUES, field.name)
+            maximum_value = getattr(MAXIMUM_VALUES, field.name)
+            current_value += 1
+            if current_value > maximum_value:
+                current_value = minimum_value
+            setattr(self.reading, field.name, current_value)
+        return self.reading

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -46,10 +46,12 @@ Topic: Documentation improvements, more fixes
 - [x] Docs: Other projects / credits
 - [x] Docs: README: Adjust layout of badges
 - [x] Docs: FAQ: Connected to wrong device?
-- [o] BLE: Select BLE adapter
-- [o] BLE: Obtain peripheral address from both ``--ble-address`` and ``CALYPSO_BLE_ADDRESS``
+- [x] Telemetry: Submit fake measurements, for supplying synthetic data to OpenCPN
+  and other clients, like ``nmea-ui``
+- [o] BLE: Select BLE adapter, using ``--ble-adapter`` or ``CALYPSO_BLE_ADAPTER``
+- [o] BLE: Obtain peripheral address from both ``--ble-address`` or ``CALYPSO_BLE_ADDRESS``
 - [o] NMEA-0183: Properly send sentence termination ``<CR><LF>``
-- [o] Telemetry: Submit fake measurements, for supplying synthetic data to OpenCPN and ``nmea-ui``
+- [o] Add more software tests
 
 
 **************
@@ -71,8 +73,7 @@ Iteration +3
 - [o] Unlock adjusting offset and calibration values
 - [o] Improve SignalK telemetry measurement ``path`` attributes,
   like ``electrical.batteries.99``
-- [o] Add more software tests
 - [o] Improve inline documentation
 - [o] Improve "naming things"
-- [o] Make everything configurable
+- [o] Make more yet hardcoded details configurable
 - [o] Add SignalK WebSocket client

--- a/doc/preflight.rst
+++ b/doc/preflight.rst
@@ -74,7 +74,7 @@ Submit::
 
 Receive::
 
-    while true; do socat -u udp-recvfrom:10110,reuseaddr,reuseport system:cat; sleep 0.3; done
+    while true; do socat -u udp-recvfrom:10110,reuseaddr,reuseport system:cat; sleep 0.05; done
 
 .. note::
 
@@ -89,3 +89,15 @@ Receive::
     Vice versa, take care to stop any ``socat`` processes listening on the designated
     port **before** starting OpenCPN. It will not croak with any error messages, but
     will just silently not receive anything.
+
+
+*****************
+Emulate telemetry
+*****************
+
+If you don't have a corresponding device on your desk, you can still use the
+program to emulate parts of its functionality. For example, use the following
+command to submit synthetic measurement readings as NMEA-0183 messages::
+
+    calypso-anemometer fake --subscribe --rate=hz_8 --target=udp+broadcast+nmea0183://255.255.255.255:10110
+

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,9 @@ setup(
         "test": [
             "pytest<8",
             "pytest-cov<4",
-        ]
+        ],
+        "fake": [
+            "aiorate>1,<2;python_version>='3.7'",
+        ],
     },
 )


### PR DESCRIPTION
## Synopsis
```bash
calypso-anemometer fake --subscribe --rate=hz_8 --target=udp+broadcast+nmea0183://255.255.255.255:10110
```
